### PR TITLE
Use carat ranges for all Pelias Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "author": "mapzen",
   "main": "index.js",
   "devDependencies": {
-    "precommit-hook": "3.0.0",
+    "precommit-hook": "^3.0.0",
     "semantic-release": "^15.0.0"
   },
   "dependencies": {
     "winston": "^2.2.0",
-    "pelias-config": "3.0.2"
+    "pelias-config": "^3.0.2"
   },
   "scripts": {
     "units": "node test/units.js",


### PR DESCRIPTION
The overhead of having to merge a Greenkeeper PR for every single change to
every single repository (which leads to cascading PRs) is too much.

Connects https://github.com/pelias/pelias/issues/366