### PR TITLE
Semantic release build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ jobs:
   include:
     - stage: release
       node_js: 10
-      script: npx semantic-release
+      script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ matrix:
 script: npm run travis
 before_install:
   - npm i -g npm
-after_success:
-  - npx semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+jobs:
+  include:
+    - stage: release
+      node_js: 10
+      script: npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ jobs:
     - stage: release
       node_js: 10
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
+      if: branch = master

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function CreateLogger( name, loggerOpts ){
       transports: [
         new winston.transports.Console( {
           colorize: pkgConfig.colorize,
+          json: pkgConfig.json,
           timestamp: pkgConfig.timestamp,
           level: pkgConfig.level,
           label: name

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "author": "mapzen",
   "main": "index.js",
   "devDependencies": {
-    "precommit-hook": "^3.0.0",
-    "semantic-release": "^15.0.0"
+    "precommit-hook": "^3.0.0"
   },
   "dependencies": {
     "winston": "^2.2.0",


### PR DESCRIPTION
This uses a new central CI script to run semantic release without putting it in dev-dependencies. See https://github.com/pelias/api/pull/1187 for the full explanation.