### PR TITLE
feat(console-log): Allow configuring logs as JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function CreateLogger( name, loggerOpts ){
       transports: [
         new winston.transports.Console( {
           colorize: pkgConfig.colorize,
+          json: pkgConfig.json,
           timestamp: pkgConfig.timestamp,
           level: pkgConfig.level,
           label: name


### PR DESCRIPTION
By setting a flag on the console logger, we can easily convert all
outgoing logs with pelias-logger to a JSON format. Many of our log
statements already use structured formats, and by printing them in JSON,
they can all be readily parsed by almost any log-reading system (like
Kibana, Honeycomb, Splunk, etc).

In my testing, Winston essentialy checks if the flag is set to any
truthy value so `true`, "true", 3, "maybe" and anything else except
`null` and `false` will enable this feature. Since it's quite robust and
handles any valid value, it does not seem necessary to add any
validation ourselves.