### PR TITLE
fix(json-logs): use stringify option

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ function CreateLogger( name, loggerOpts ){
         new winston.transports.Console( {
           colorize: pkgConfig.colorize,
           json: pkgConfig.json,
+          stringify: true,
           timestamp: pkgConfig.timestamp,
           level: pkgConfig.level,
           label: name


### PR DESCRIPTION
This forces the JSON output to be on a single line. Without it, it's not
easy to parse the logs.

Connects https://github.com/pelias/logger/pull/47

See https://github.com/winstonjs/winston/blob/2.4.0/docs/transports.md#console-transport