### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "precommit-hook": "^3.0.0"
   },
   "dependencies": {
-    "winston": "^2.2.0",
-    "pelias-config": "^4.0.0"
+    "pelias-config": "^5.0.1",
+    "winston": "^2.4.5"
   },
   "scripts": {
     "units": "node test/units.js",


### PR DESCRIPTION
This PR bumps `winston` to `2.4.5` (the latest and likely final release in version 2) to resolve this warning message I was seeing when using the `fuzzy-tester` (which consumes this module).
https://github.com/winstonjs/winston/issues/1797

I've also updated the only other dependency `pelias-config` since we rarely touch this module.

related https://github.com/pelias/logger/issues/53